### PR TITLE
test: 单元测试兼容不同环境电脑

### DIFF
--- a/tests/phpunit/ModuleTest.php
+++ b/tests/phpunit/ModuleTest.php
@@ -9,7 +9,7 @@ class ModuleTest extends TestCase
     {
         $os = PyLoader::import('os');
         $uname = $os->uname();
-        $this->assertEquals($uname->sysname, 'Linux');
+        $this->assertEquals(php_uname('s'), $uname->sysname);
     }
 
     public function testNewObject()


### PR DESCRIPTION
1. 这个测试用例在我的 mac 上跑总是失败，因此改为用php的函数获取来对python获取的值对比的方式。
2. 对比时把期望值调到前面，符合assertEquals函数签名