### PR TITLE
fix: 如果指定了 --with-python-version 参数，则优先使用

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -6,6 +6,13 @@ PHP_ARG_WITH([python_dir],
   [AS_HELP_STRING([[--with-python-dir[=DIR]]],
     [Specify python installation dir, default is /opt/anaconda3])], [no], [no])
 
+
+PHP_ARG_WITH([python_version],
+  [version of python],
+  [AS_HELP_STRING([[--with-python-version[=VERSION]]],
+    [Specify version of python, default is 3.11])], [no], [no])
+
+
 PHP_ARG_ENABLE([phpy],
   [whether to enable phpy support],
   [AS_HELP_STRING([--enable-phpy],
@@ -17,14 +24,15 @@ if test "$PHP_PHPY" != "no"; then
      PHP_PYTHON_DIR="/opt/anaconda3"
   fi
 
-  if test -f "${PHP_PYTHON_DIR}/bin/python"; then
-     PHP_PYTHON_VERSION=$("${PHP_PYTHON_DIR}/bin/python" -c "import sys; print('%d.%d'%(sys.version_info.major, sys.version_info.minor))")
-  elif test -f "${PHP_PYTHON_DIR}/python"; then
-     PHP_PYTHON_VERSION=$("${PHP_PYTHON_DIR}/python" -c "import sys; print('%d.%d'%(sys.version_info.major, sys.version_info.minor))")
-  else
-     PHP_PYTHON_VERSION="3.11"
+  if test "$PHP_PYTHON_VERSION" = "no"; then
+    if test -f "${PHP_PYTHON_DIR}/bin/python"; then
+      PHP_PYTHON_VERSION=$("${PHP_PYTHON_DIR}/bin/python" -c "import sys; print('%d.%d'%(sys.version_info.major, sys.version_info.minor))")
+    elif test -f "${PHP_PYTHON_DIR}/python"; then
+      PHP_PYTHON_VERSION=$("${PHP_PYTHON_DIR}/python" -c "import sys; print('%d.%d'%(sys.version_info.major, sys.version_info.minor))")
+    else
+      PHP_PYTHON_VERSION="3.11"
+    fi
   fi
-
   AC_MSG_RESULT([PYTHON_DIR=${PHP_PYTHON_DIR}])
   AC_MSG_RESULT([PYTHON_VERSION=${PHP_PYTHON_VERSION}])
 


### PR DESCRIPTION
configure 时 python-version 现在是自动获取，但某些情况下可能获取不到。因为不存在 `${PHP_PYTHON_DIR}/bin/python` 这个命令。

实际上在 mac 上只有 ${PHP_PYTHON_DIR}/bin/python3.12 ，并没有 ${PHP_PYTHON_DIR}/bin/python 命令。

因此这里还是应该支持 `--with-python-version` 参数，只有在没有指定这个参数的情况下再尝试自动获取。