### PR TITLE
fix core dump when key wasn’t string.

### DIFF
--- a/src/bridge/core.cc
+++ b/src/bridge/core.cc
@@ -248,7 +248,7 @@ static void dict2array(PyObject *pv, zval *zv) {
         py2php_fn(value, &item);
 
         ssize_t len;
-        const char *key = phpy::python::string2utf8(next, &len);
+        const char *key = phpy::python::string2utf8(PyObject_Str(next), &len);
         add_assoc_zval_ex(zv, key, len, &item);
     }
     Py_DECREF(iter);

--- a/tests/phpunit/DictTest.php
+++ b/tests/phpunit/DictTest.php
@@ -61,4 +61,16 @@ class DictTest extends TestCase
         }
         $this->assertEquals($keys, array_keys($map));
     }
+
+    public function testKeyNotString()
+    {
+        $pycode = <<<CODE
+key1 = ("sum", "数量")
+key2 = ("mean", "数量")
+dict_data = {key1: 1, key2: 2}
+CODE;
+        $json = json_encode(PyCore::scalar(PyCore::eval($pycode)->dict_data));
+        $result = "{\"('sum', '\u6570\u91cf')\":1,\"('mean', '\u6570\u91cf')\":2}";
+        $this->assertEquals($json, $result);
+    }
 }


### PR DESCRIPTION
```
{"('sum', '数量')":256.0,"('mean', '数量')":4.1967213115}
```
```
array(2) {
  ["('sum', '数量')"]=>
  float(256)
  ["('mean', '数量')"]=>
  float(4.19672131147541)
}

```
```
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
Core was generated by `php pandas.php'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000055ffb2b60273 in add_assoc_zval_ex ()
[Current thread is 1 (Thread 0x7fd7cacc9e00 (LWP 9483))]
(gdb) bt
#0  0x000055ffb2b60273 in add_assoc_zval_ex ()
#1  0x00007fd7ca6ce55f in dict2array (pv=0x7fd7add88b00, zv=0x7fd7caa142f0) at /home/ubuntu/phpy/src/bridge/core.cc:252
#2  0x00007fd7ca6d2057 in zim_PyCore_scalar (execute_data=<optimized out>, return_value=0x7fd7caa142f0) at /home/ubuntu/phpy/src/php/core.cc:160
#3  0x000055ffb2cb0b74 in execute_ex ()
#4  0x000055ffb2cca1d7 in zend_execute ()
#5  0x000055ffb2b56ae2 in zend_execute_scripts ()
#6  0x000055ffb2a875f2 in php_execute_script ()
#7  0x000055ffb2df6fd7 in do_cli ()
#8  0x000055ffb2df85a5 in main ()
```