### PR TITLE
fix unpack dict

### DIFF
--- a/src/php/dict.cc
+++ b/src/php/dict.cc
@@ -133,10 +133,10 @@ ZEND_METHOD(PyDict, key) {
     zval key_zv;
     py2php(current, &key_zv);
     if (Z_TYPE(key_zv) == IS_LONG || Z_TYPE(key_zv) == IS_STRING) {
-        RETURN_ZVAL(&key_zv, 1, 0);
+        RETURN_ZVAL(&key_zv, 0, 0);
     } else {
         convert_to_string(&key_zv);
-        RETURN_ZVAL(&key_zv, 1, 0);
+        RETURN_ZVAL(&key_zv, 0, 0);
     }
 }
 

--- a/src/php/dict.cc
+++ b/src/php/dict.cc
@@ -130,7 +130,14 @@ ZEND_METHOD(PyDict, valid) {
 
 ZEND_METHOD(PyDict, key) {
     auto current = phpy_object_iterator_current(ZEND_THIS);
-    py2php(current, return_value);
+    zval key_zv;
+    py2php(current, &key_zv);
+    if (Z_TYPE(key_zv) == IS_LONG || Z_TYPE(key_zv) == IS_STRING) {
+        RETURN_ZVAL(&key_zv, 1, 0);
+    } else {
+        convert_to_string(&key_zv);
+        RETURN_ZVAL(&key_zv, 1, 0);
+    }
 }
 
 ZEND_METHOD(PyDict, current) {


### PR DESCRIPTION
修正展开PyDict时报错 “Keys must be of type int|string during array unpacking”，比如 `[...PyCore::import('builtins')->__dict__]`