### PR TITLE
修正只有kwargs没有args时报错

### DIFF
--- a/src/bridge/core.cc
+++ b/src/bridge/core.cc
@@ -364,6 +364,10 @@ void CallObject::call() {
     PyObject *value;
     if (argc == 0 && kwargs == nullptr) {
         value = PyObject_CallNoArgs(fn);
+    } else if (argc == 0 && kwargs != nullptr) {
+        PyObject *empty_tuple = PyTuple_New(0);
+        value = PyObject_Call(fn, empty_tuple, kwargs);
+        Py_DECREF(empty_tuple);
     } else {
         value = PyObject_Call(fn, args, kwargs);
     }

--- a/src/bridge/core.cc
+++ b/src/bridge/core.cc
@@ -364,11 +364,8 @@ void CallObject::call() {
     PyObject *value;
     if (argc == 0 && kwargs == nullptr) {
         value = PyObject_CallNoArgs(fn);
-    } else if (argc == 0 && kwargs != nullptr) {
-        PyObject *empty_tuple = PyTuple_New(0);
-        value = PyObject_Call(fn, empty_tuple, kwargs);
-        Py_DECREF(empty_tuple);
     } else {
+        args = args == nullptr ? PyTuple_New(0) : args;
         value = PyObject_Call(fn, args, kwargs);
     }
     if (value != NULL) {

--- a/tests/phpunit/CollectionsTest.php
+++ b/tests/phpunit/CollectionsTest.php
@@ -20,6 +20,6 @@ class CollectionsTest extends TestCase
 
         $words = ['red', 'blue', 'red', 'green', 'blue', 'blue'];
         $word_counts = $Counter($words);
-        $this->assertEquals(PyCore::dict($word_counts), PyCore::dict(['blue' => 3, 'red' => 2, 'green' => 1]));
+        $this->assertEquals(['blue' => 3, 'red' => 2, 'green' => 1], [...PyCore::dict($word_counts)]);
     }
 }

--- a/tests/phpunit/CollectionsTest.php
+++ b/tests/phpunit/CollectionsTest.php
@@ -12,6 +12,9 @@ class CollectionsTest extends TestCase
         $this->assertEquals('阮奇桢', $p1->name);
         $this->assertEquals(40, $p1->age);
         $this->assertEquals('男', $p1->gender);
+
+        [$name, $age, $gender] = $p1;
+        $this->assertEquals(['阮奇桢', 40, '男'], [(string)$name, (int)$age, (string)$gender]);
     }
 
     public function testCounter()

--- a/tests/phpunit/CollectionsTest.php
+++ b/tests/phpunit/CollectionsTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class CollectionsTest extends TestCase
+{
+    public function testNamedTuple()
+    {
+        $namedtuple = PyCore::import('collections')->namedtuple;
+        $Person = $namedtuple('Person', ['name', 'age', 'gender']);
+        $p1 = $Person(name: '阮奇桢', age: 40, gender: '男');
+        $this->assertEquals('阮奇桢', $p1->name);
+        $this->assertEquals(40, $p1->age);
+        $this->assertEquals('男', $p1->gender);
+    }
+
+    public function testCounter()
+    {
+        $Counter = PyCore::import('collections')->Counter;
+
+        $words = ['red', 'blue', 'red', 'green', 'blue', 'blue'];
+        $word_counts = $Counter($words);
+        $this->assertEquals(PyCore::dict($word_counts), PyCore::dict(['blue' => 3, 'red' => 2, 'green' => 1]));
+    }
+}


### PR DESCRIPTION
复现代码
```
$namedtuple = PyCore::import('collections')->namedtuple;

$Person = $namedtuple('Person', ["name", "age", "gender"]);
$p1 = $Person(name: "阮奇桢", age: 40, gender: "男");
PyCore::print($p1->name);
```
运行会 `[1]    11886 segmentation fault  php test.php`
gdb调试发现在 `value = PyObject_Call(fn, args, kwargs);`处 出错，根据文档 [调用对象的 API](https://docs.python.org/zh-cn/3/c-api/call.html?highlight=pyobject_call#c.PyObject_CallOneArg) PyObject_Call的第二个参数 args 是可以为空的，此时应该传 空元组。

如果不改 bride/core.cc的话 第一个参数必须是 args，所以php中要改成 `$p1 = $Person("阮奇桢", age: 40, gender: "男");`，但这样显得很奇怪，与python不一致了