### PR TITLE
fix core dump when "new PyType"

### DIFF
--- a/src/php/object.cc
+++ b/src/php/object.cc
@@ -98,7 +98,9 @@ static zend_object *phpy_object_create_object(zend_class_entry *ce) {
 
 static void phpy_object_free_object(zend_object *object) {
     Object *object_object = phpy_object_get_object(object);
-    Py_DECREF(object_object->object);
+    if (object_object->object != NULL) {
+        Py_DECREF(object_object->object);
+    }
     zend_object_std_dtor(&object_object->std);
 }
 

--- a/tests/phpunit/IterTest.php
+++ b/tests/phpunit/IterTest.php
@@ -19,4 +19,15 @@ class IterTest extends TestCase
         $this->assertIsArray($list);
         $this->assertEquals(count($list), 5);
     }
+
+    function testNewIter()
+    {
+        try {
+            new PyIter;
+        } catch (Error $error) {
+            $this->assertStringContainsString('private PyIter::__construct()', $error->getMessage());
+            $success = false;
+        }
+        $this->assertFalse($success);
+    }
 }

--- a/tests/phpunit/TypeTest.php
+++ b/tests/phpunit/TypeTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+class TypeTest extends TestCase
+{
+    function testType()
+    {
+        $type = PyCore::type(1);
+        $this->assertTrue($type instanceof PyType);
+
+        $this->assertEquals("<class 'int'>", (string)$type);
+    }
+
+    function testNewType()
+    {
+        try {
+            new PyType;
+        } catch (Error $error) {
+            $this->assertStringContainsString('private PyType::__construct()', $error->getMessage());
+            $success = false;
+        }
+        $this->assertFalse($success);
+    }
+}


### PR DESCRIPTION
复现代码
```
$type = new PyType;
```
修改前运行会coredump，修改后可以抛出异常
```
Fatal error: Uncaught Error: Call to private PyType::__construct() from global scope in /home/mrpzx/git/phpy/phpy-examples/test.php:3
Stack trace:
#0 {main}
  thrown in /home/mrpzx/git/phpy/phpy-examples/test.php on line 3
```