### PR TITLE
Fix python config

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -42,6 +42,8 @@ jobs:
           sudo sh -c "echo 'extension=phpy.so' > /etc/php/${PHP_VERSION}/cli/conf.d/90-phpy.ini"
           php --ri phpy
       - name: Run phpunit tests
+        env:
+          LC_ALL: POSIX # Do not remove this line, PR: https://github.com/swoole/phpy/pull/45
         run: |
           composer install
           composer test

--- a/src/php/core.cc
+++ b/src/php/core.cc
@@ -217,6 +217,7 @@ PHP_MINIT_FUNCTION(phpy) {
     PyConfig py_config;
     PyConfig_InitPythonConfig(&py_config);
     py_config.install_signal_handlers = 0; // ignore signal
+    py_config.parse_argv = 0;
     Py_InitializeFromConfig(&py_config);
     PyConfig_Clear(&py_config);
 #else

--- a/src/php/core.cc
+++ b/src/php/core.cc
@@ -211,7 +211,18 @@ PHP_MINIT_FUNCTION(phpy) {
         return FAILURE;
     }
     srand(time(NULL));
+
+#if PY_VERSION_HEX >= 0x03080000
+    // doc: https://docs.python.org/3/c-api/init_config.html
+    PyConfig py_config;
+    PyConfig_InitPythonConfig(&py_config);
+    py_config.install_signal_handlers = 0; // ignore signal
+    Py_InitializeFromConfig(&py_config);
+    PyConfig_Clear(&py_config);
+#else
     Py_InitializeEx(0);
+#endif
+
     module_phpy = PyImport_ImportModule("phpy");
     if (!module_phpy) {
         PyErr_Print();

--- a/tests/phpunit/LocaleTest.php
+++ b/tests/phpunit/LocaleTest.php
@@ -1,0 +1,31 @@
+<?php
+
+
+namespace phpunit;
+
+use PHPUnit\Framework\TestCase;
+use PyCore;
+
+class LocaleTest extends TestCase
+{
+    public function testLocale()
+    {
+        $fileName = __DIR__ . '/test_locale.py';
+        file_put_contents($fileName, <<<PYCODE
+        import locale;
+        import sys;
+
+        print(locale.getdefaultlocale())
+        print(locale.getpreferredencoding())
+        print(sys.getdefaultencoding())
+        print(sys.getfilesystemencoding())
+        PYCODE);
+
+        $result = shell_exec('python ' . $fileName);
+        unlink($fileName);
+
+        $locale = PyCore::import('locale');
+        $sys = PyCore::import('sys');
+        $this->assertEquals(sprintf("%s\n%s\n%s\n%s\n", $locale->getdefaultlocale(), $locale->getpreferredencoding(), $sys->getdefaultencoding(), $sys->getfilesystemencoding()), $result);
+    }
+}


### PR DESCRIPTION
Fix some encoding problems

**python:**

```python
import locale;
import sys;

print(locale.getdefaultlocale())
print(locale.getpreferredencoding())
print(sys.getdefaultencoding())
print(sys.getfilesystemencoding())
```

**php:**

```php
$locale = PyCore::import('locale');
$sys = PyCore::import('sys');
var_dump((string) $locale->getdefaultlocale());
var_dump((string) $locale->getpreferredencoding());
var_dump((string) $sys->getdefaultencoding());
var_dump((string) $sys->getfilesystemencoding());
```